### PR TITLE
Fill out signer functions for Osmosis modules

### DIFF
--- a/client/codec/osmosis/v15/x/gamm/types/msgs.go
+++ b/client/codec/osmosis/v15/x/gamm/types/msgs.go
@@ -26,15 +26,19 @@ func (msg MsgJoinPool) Route() string { return "" }
 func (msg MsgJoinPool) Type() string { return "" }
 
 func (msg MsgJoinPool) ValidateBasic() error {
-	return nil
+	panic("MsgJoinPool ValidateBasic Unimplemented")
 }
 
 func (msg MsgJoinPool) GetSignBytes() []byte {
-	return nil
+	panic("MsgJoinPool GetSignBytes Unimplemented")
 }
 
 func (msg MsgJoinPool) GetSigners() []sdk.AccAddress {
-	return nil
+	addr, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{addr}
 }
 
 // Exit
@@ -43,15 +47,19 @@ func (msg MsgExitPool) Route() string { return "" }
 func (msg MsgExitPool) Type() string { return "" }
 
 func (msg MsgExitPool) ValidateBasic() error {
-	return nil
+	panic("MsgExitPool ValidateBasic Unimplemented")
 }
 
 func (msg MsgExitPool) GetSignBytes() []byte {
-	return nil
+	panic("MsgExitPool GetSignBytes Unimplemented")
 }
 
 func (msg MsgExitPool) GetSigners() []sdk.AccAddress {
-	return nil
+	addr, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{addr}
 }
 
 // SwapExactIn
@@ -60,15 +68,19 @@ func (msg MsgSwapExactAmountIn) Route() string { return "" }
 func (msg MsgSwapExactAmountIn) Type() string { return "" }
 
 func (msg MsgSwapExactAmountIn) ValidateBasic() error {
-	return nil
+	panic("MsgSwapExactAmountIn ValidateBasic Unimplemented")
 }
 
 func (msg MsgSwapExactAmountIn) GetSignBytes() []byte {
-	return nil
+	panic("MsgSwapExactAmountIn GetSignBytes Unimplemented")
 }
 
 func (msg MsgSwapExactAmountIn) GetSigners() []sdk.AccAddress {
-	return nil
+	addr, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{addr}
 }
 
 // SwapExactOut
@@ -77,15 +89,19 @@ func (msg MsgSwapExactAmountOut) Route() string { return "" }
 func (msg MsgSwapExactAmountOut) Type() string { return "" }
 
 func (msg MsgSwapExactAmountOut) ValidateBasic() error {
-	return nil
+	panic("MsgSwapExactAmountOut ValidateBasic Unimplemented")
 }
 
 func (msg MsgSwapExactAmountOut) GetSignBytes() []byte {
-	return nil
+	panic("MsgSwapExactAmountOut GetSignBytes Unimplemented")
 }
 
 func (msg MsgSwapExactAmountOut) GetSigners() []sdk.AccAddress {
-	return nil
+	addr, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{addr}
 }
 
 // JoinSwapExternIn
@@ -94,15 +110,19 @@ func (msg MsgJoinSwapExternAmountIn) Route() string { return "" }
 func (msg MsgJoinSwapExternAmountIn) Type() string { return "" }
 
 func (msg MsgJoinSwapExternAmountIn) ValidateBasic() error {
-	return nil
+	panic("MsgJoinSwapExternAmountIn ValidateBasic Unimplemented")
 }
 
 func (msg MsgJoinSwapExternAmountIn) GetSignBytes() []byte {
-	return nil
+	panic("MsgJoinSwapExternAmountIn GetSignBytes Unimplemented")
 }
 
 func (msg MsgJoinSwapExternAmountIn) GetSigners() []sdk.AccAddress {
-	return nil
+	addr, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{addr}
 }
 
 // JoinSwapShareOut
@@ -111,15 +131,19 @@ func (msg MsgJoinSwapShareAmountOut) Route() string { return "" }
 func (msg MsgJoinSwapShareAmountOut) Type() string { return "" }
 
 func (msg MsgJoinSwapShareAmountOut) ValidateBasic() error {
-	return nil
+	panic("MsgJoinSwapShareAmountOut ValidateBasic Unimplemented")
 }
 
 func (msg MsgJoinSwapShareAmountOut) GetSignBytes() []byte {
-	return nil
+	panic("MsgJoinSwapShareAmountOut GetSignBytes Unimplemented")
 }
 
 func (msg MsgJoinSwapShareAmountOut) GetSigners() []sdk.AccAddress {
-	return nil
+	addr, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{addr}
 }
 
 // ExitSwapShareIn
@@ -128,15 +152,19 @@ func (msg MsgExitSwapShareAmountIn) Route() string { return "" }
 func (msg MsgExitSwapShareAmountIn) Type() string { return "" }
 
 func (msg MsgExitSwapShareAmountIn) ValidateBasic() error {
-	return nil
+	panic("MsgExitSwapShareAmountIn ValidateBasic Unimplemented")
 }
 
 func (msg MsgExitSwapShareAmountIn) GetSignBytes() []byte {
-	return nil
+	panic("MsgExitSwapShareAmountIn GetSignBytes Unimplemented")
 }
 
 func (msg MsgExitSwapShareAmountIn) GetSigners() []sdk.AccAddress {
-	return nil
+	addr, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{addr}
 }
 
 // ExitSwapExternOut
@@ -145,15 +173,19 @@ func (msg MsgExitSwapExternAmountOut) Route() string { return "" }
 func (msg MsgExitSwapExternAmountOut) Type() string { return "" }
 
 func (msg MsgExitSwapExternAmountOut) ValidateBasic() error {
-	return nil
+	panic("MsgExitSwapExternAmountOut ValidateBasic Unimplemented")
 }
 
 func (msg MsgExitSwapExternAmountOut) GetSignBytes() []byte {
-	return nil
+	panic("MsgExitSwapExternAmountOut GetSignBytes Unimplemented")
 }
 
 func (msg MsgExitSwapExternAmountOut) GetSigners() []sdk.AccAddress {
-	return nil
+	addr, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{addr}
 }
 
 // Old Message Types
@@ -164,15 +196,19 @@ func (msg MsgCreatePool) Route() string { return "" }
 func (msg MsgCreatePool) Type() string { return "" }
 
 func (msg MsgCreatePool) ValidateBasic() error {
-	return nil
+	panic("MsgCreatePool ValidateBasic Unimplemented")
 }
 
 func (msg MsgCreatePool) GetSignBytes() []byte {
-	return nil
+	panic("MsgCreatePool GetSignBytes Unimplemented")
 }
 
 func (msg MsgCreatePool) GetSigners() []sdk.AccAddress {
-	return nil
+	addr, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{addr}
 }
 
 // CreatePool
@@ -181,13 +217,17 @@ func (msg MsgCreateBalancerPool) Route() string { return "" }
 func (msg MsgCreateBalancerPool) Type() string { return "" }
 
 func (msg MsgCreateBalancerPool) ValidateBasic() error {
-	return nil
+	panic("MsgCreateBalancerPool ValidateBasic Unimplemented")
 }
 
 func (msg MsgCreateBalancerPool) GetSignBytes() []byte {
-	return nil
+	panic("MsgCreateBalancerPool GetSignBytes Unimplemented")
 }
 
 func (msg MsgCreateBalancerPool) GetSigners() []sdk.AccAddress {
-	return nil
+	addr, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{addr}
 }

--- a/client/codec/osmosis/v15/x/poolmanager/types/msgs.go
+++ b/client/codec/osmosis/v15/x/poolmanager/types/msgs.go
@@ -19,15 +19,19 @@ func (msg MsgSwapExactAmountIn) Route() string { return "" }
 func (msg MsgSwapExactAmountIn) Type() string { return "" }
 
 func (msg MsgSwapExactAmountIn) ValidateBasic() error {
-	return nil
+	panic("MsgSwapExactAmountIn ValidateBasic Unimplemented")
 }
 
 func (msg MsgSwapExactAmountIn) GetSignBytes() []byte {
-	return nil
+	panic("MsgSwapExactAmountIn GetSignBytes Unimplemented")
 }
 
 func (msg MsgSwapExactAmountIn) GetSigners() []sdk.AccAddress {
-	return nil
+	addr, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{addr}
 }
 
 // SplitRouteSwapExactAmountIn
@@ -36,15 +40,19 @@ func (msg MsgSplitRouteSwapExactAmountIn) Route() string { return "" }
 func (msg MsgSplitRouteSwapExactAmountIn) Type() string { return "" }
 
 func (msg MsgSplitRouteSwapExactAmountIn) ValidateBasic() error {
-	return nil
+	panic("MsgSplitRouteSwapExactAmountIn ValidateBasic Unimplemented")
 }
 
 func (msg MsgSplitRouteSwapExactAmountIn) GetSignBytes() []byte {
-	return nil
+	panic("MsgSplitRouteSwapExactAmountIn GetSignBytes Unimplemented")
 }
 
 func (msg MsgSplitRouteSwapExactAmountIn) GetSigners() []sdk.AccAddress {
-	return nil
+	addr, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{addr}
 }
 
 // SwapExactAmountOut
@@ -53,15 +61,19 @@ func (msg MsgSwapExactAmountOut) Route() string { return "" }
 func (msg MsgSwapExactAmountOut) Type() string { return "" }
 
 func (msg MsgSwapExactAmountOut) ValidateBasic() error {
-	return nil
+	panic("MsgSwapExactAmountOut ValidateBasic Unimplemented")
 }
 
 func (msg MsgSwapExactAmountOut) GetSignBytes() []byte {
-	return nil
+	panic("MsgSwapExactAmountOut GetSignBytes Unimplemented")
 }
 
 func (msg MsgSwapExactAmountOut) GetSigners() []sdk.AccAddress {
-	return nil
+	addr, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{addr}
 }
 
 // SplitRouteSwapExactAmountOut
@@ -70,13 +82,17 @@ func (msg MsgSplitRouteSwapExactAmountOut) Route() string { return "" }
 func (msg MsgSplitRouteSwapExactAmountOut) Type() string { return "" }
 
 func (msg MsgSplitRouteSwapExactAmountOut) ValidateBasic() error {
-	return nil
+	panic("MsgSplitRouteSwapExactAmountOut ValidateBasic Unimplemented")
 }
 
 func (msg MsgSplitRouteSwapExactAmountOut) GetSignBytes() []byte {
-	return nil
+	panic("MsgSplitRouteSwapExactAmountOut GetSignBytes Unimplemented")
 }
 
 func (msg MsgSplitRouteSwapExactAmountOut) GetSigners() []sdk.AccAddress {
-	return nil
+	addr, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{addr}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cosmos/gogoproto v1.4.8
 	github.com/cosmos/ibc-go/v7 v7.0.0
 	google.golang.org/grpc v1.54.0
+	google.golang.org/protobuf v1.30.0
 )
 
 require (
@@ -132,7 +133,6 @@ require (
 	golang.org/x/term v0.7.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4 // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/query/tx.go
+++ b/query/tx.go
@@ -42,6 +42,9 @@ func TxsRPC(q *Query, req *txTypes.GetTxsEventRequest, codec client.Codec) (*txT
 	}
 
 	for _, tx := range res.GetTxs() {
+		// BUG: This function errors out on the first type error, meaning that the first message that fails ends the unpacking process
+		// Since TXs can have multiple messages, this means that we won't be able to process the messages that come after the first error
+		// We may want to pull out the unpacking logic into a separate function that can be called on each message individually but not fail hard
 		tx.UnpackInterfaces(codec.InterfaceRegistry)
 	}
 


### PR DESCRIPTION
During runs of using this functionality in an external repo as a drop in replacement for Lens, I found us using GetSigners for various reasons. These will need to be filled out properly so that we can use them in the other project.

I also added `panic` to all deliberately unimplemented Msg interface functions for the time being to make note of their usage instead of returning `nil` silently.